### PR TITLE
Connect-vRNIServer: fix variable for found is a local or remote username

### DIFF
--- a/PowervRNI.psm1
+++ b/PowervRNI.psm1
@@ -450,7 +450,7 @@ function Connect-vRNIServer {
   }
 
   # Figure out if the username is a local or remote username
-  $parts = $Username.split("@")
+  $parts = $requestFormat.username.split("@")
   # If no domain param is given, use the default LOCAL domain and populate the "domain" field
   if ($parts[1] -eq "local" -Or $UseLocalAuth -eq $True -Or $Domain -eq "LOCAL") {
     $requestFormat.domain = @{


### PR DESCRIPTION
It don't work when you using credential connect-vrni without parameter (only ip address of vrni server) or using -credential parameter