### PR TITLE
switch to mcr.microsoft.com in dockerfile

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM microsoft/powershell:ubuntu16.04
+FROM mcr.microsoft.com/powershell:ubuntu16.04
 
 # Set working directory so stuff doesn't end up in /
 WORKDIR /root


### PR DESCRIPTION
Please use mcr.microsoft.com for the best support. https://azure.microsoft.com/en-us/blog/microsoft-syndicates-container-catalog/ 
Minimal change but please accept as we will quit publishing to the old location soon.